### PR TITLE
http.createClient is deprecated. Amended it to use http.request instead

### DIFF
--- a/datasift.js
+++ b/datasift.js
@@ -150,15 +150,18 @@ DataSift.prototype.connect = function() {
 		};
 
 		//Create an http client
-		var client = http.createClient(this.port, this.host);
-		
-		//Make the request
-		this.request = client.request("GET", '/', headers);
+		this.request = http.request({
+			port: this.port,
+			host: this.host,
+			headers: headers,
+			method: 'GET',
+			path: '/'
+		});
 
 		//Check for an error on connection
-		client.on('error', function(){
-			self.errorCallback(new Error('Error connecting to DataSift: Could not reach DataSift. Check your internet connection.'));
-		});
+ 		this.request.on('error', function(){
+      			self.errorCallback(new Error('Error connecting to DataSift: Could not reach DataSift. Check your internet connection.'));
+ 		});
 
 		//Add a connection timeout
 		this.connectTimeout = setTimeout(function() {


### PR DESCRIPTION
Maybe someone has already completed this and it is waiting in the pull queue. I should really check but its such a small change I thought I'd go ahead and do it anyway.
